### PR TITLE
Add hardware flow control pin definitions

### DIFF
--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -6,6 +6,12 @@ menu "USB UART Bridge Example"
     config BOARD_UART_RXD_PIN
         int "UART RXD pin"
         default 13
+    config BOARD_UART_RTS_PIN
+        int "UART RTS pin"
+        default -1
+    config BOARD_UART_CTS_PIN
+        int "UART CTS pin"
+        default -1
     config BOARD_ZG23_RESET_PIN
         int "ZG23 RESET pin"
         default 4

--- a/main/usb_uart_bridge_main.c
+++ b/main/usb_uart_bridge_main.c
@@ -34,6 +34,8 @@ const uint64_t MAGIC_BOOTLOADER_TRIGGER_TIMEOUT_MICROS = 5000000;
 #define BOARD_UART_PORT        UART_NUM_1
 #define BOARD_UART_TXD_PIN     CONFIG_BOARD_UART_TXD_PIN
 #define BOARD_UART_RXD_PIN     CONFIG_BOARD_UART_RXD_PIN
+#define BOARD_UART_RTS_PIN     CONFIG_BOARD_UART_RTS_PIN
+#define BOARD_UART_CTS_PIN     CONFIG_BOARD_UART_CTS_PIN
 #define UART_RX_BUF_SIZE       CONFIG_UART_RX_BUF_SIZE
 #define UART_TX_BUF_SIZE       CONFIG_UART_TX_BUF_SIZE
 #define UART_QUEUE_SIZE        16
@@ -447,14 +449,24 @@ void app_main(void)
         .data_bits = CFG_DATA_BITS(s_data_bits_active),
         .parity = CFG_PARITY(s_parity_active),
         .stop_bits = CFG_STOP_BITS(s_stop_bits_active),
-        .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
+        #if BOARD_UART_RTS_PIN < 0 || BOARD_UART_CTS_PIN < 0
+            .flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
+        #else
+            .flow_ctrl = UART_HW_FLOWCTRL_CTS_RTS,
+        #endif
         .source_clk = UART_SCLK_APB,
     };
 
     QueueHandle_t uart_queue = NULL;
     uart_driver_install(BOARD_UART_PORT, UART_RX_BUF_SIZE, UART_TX_BUF_SIZE, UART_QUEUE_SIZE, &uart_queue, 0);
     uart_param_config(BOARD_UART_PORT, &uart_config);
-    uart_set_pin(BOARD_UART_PORT, BOARD_UART_TXD_PIN, BOARD_UART_RXD_PIN, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
+    uart_set_pin(
+        BOARD_UART_PORT,
+        BOARD_UART_TXD_PIN,
+        BOARD_UART_RXD_PIN,
+        BOARD_UART_RTS_PIN,
+        BOARD_UART_CTS_PIN
+    );
     ESP_LOGI(TAG, "init UART%d: %"PRIu32 " %s %s %s", BOARD_UART_PORT, s_baud_rate_active, STR_DATA_BITS(s_data_bits_active), STR_PARITY(s_parity_active), STR_STOP_BITS(s_stop_bits_active));
 
     board_zg23_reset_gpio_init();


### PR DESCRIPTION
If hardware flow control is enabled by setting the RTS and CTS pins to a positive number, we switch the UART to `UART_HW_FLOWCTRL_CTS_RTS`. This is disabled by default.