### PR TITLE
Remove `home_assistant_domain` from generated manifest

### DIFF
--- a/build_ewt_manifest.py
+++ b/build_ewt_manifest.py
@@ -8,7 +8,6 @@ version = parser.parse_args().v
 manifest = {
   "name": "zwa-2.usb-uart-bridge",
   "version": version,
-  "home_assistant_domain": "esphome",
   "new_install_prompt_erase": "false",
   "builds": [
     {


### PR DESCRIPTION
Addresses https://github.com/NabuCasa/zwave-esp-bridge/pull/24#discussion_r2384294301